### PR TITLE
Do not force SHARED library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(include)
 include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_library(${PROJECT_NAME} SHARED src/console.cpp)
+add_library(${PROJECT_NAME} src/console.cpp)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
We need static for cross compiling portability, and to compile this we had to patch this file since it does not obey the system settings.

This is applicable to hydro too. 
