### PR TITLE
Use c++11 instead of boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ compiler:
 env:
   - BUILD_TYPE=Debug
   - BUILD_TYPE=RelWithDebInfo
-install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y libboost-system-dev libboost-thread-dev
 script:
   - mkdir build
   - cd build 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,31 +21,31 @@ if (HAS_VISIBILITY)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 endif()
 
-find_package(Boost COMPONENTS system thread REQUIRED)
+if(NOT WIN32)
+  # Use c++11 compiler flag, since it's needed for console.cpp
+  # It isn't in a header file, so it doesn't need to be exported
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
 
 if(MSVC OR MSVC90 OR MSVC10)
   set(MSVC ON)
 endif (MSVC OR MSVC90 OR MSVC10)
 
-if(MSVC)
-  add_definitions(-DBOOST_ALL_NO_LIB)
-endif(MSVC)
-
 include_directories(include)
-include_directories(${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
 
 if(NOT DEFINED BUILD_SHARED_LIBS)
   option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
 endif()
 
 add_library(${PROJECT_NAME} src/console.cpp)
-target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION
                ${CONSOLE_BRIDGE_MAJOR_VERSION}.${CONSOLE_BRIDGE_MINOR_VERSION})
 
 install(TARGETS ${PROJECT_NAME}
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 install(DIRECTORY include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -35,10 +35,12 @@
 /* Author: Ryan Luna, Ioan Sucan */
 
 #include "console_bridge/console.h"
-#include <boost/thread/mutex.hpp>
-#include <iostream>
+
 #include <cstdio>
 #include <cstdarg>
+
+#include <iostream>
+#include <mutex>
 
 /// @cond IGNORE
 
@@ -55,7 +57,7 @@ struct DefaultOutputHandler
     console_bridge::OutputHandler   *output_handler_;
     console_bridge::OutputHandler   *previous_output_handler_;
     console_bridge::LogLevel         logLevel_;
-    boost::mutex                     lock_; // it is likely the outputhandler does some I/O, so we serialize it
+    std::mutex                       lock_; // it is likely the outputhandler does some I/O, so we serialize it
 };
 
 // we use this function because we want to handle static initialization correctly
@@ -70,7 +72,7 @@ static DefaultOutputHandler* getDOH(void)
 
 #define USE_DOH                                                                \
     DefaultOutputHandler *doh = getDOH();                                      \
-    boost::mutex::scoped_lock slock(doh->lock_)
+    std::lock_guard<std::mutex> lock_guard(doh->lock_)
 
 #define MAX_BUFFER_SIZE 1024
 


### PR DESCRIPTION
This package uses only a small amount of boost
for a mutex and scoped_lock.
These are replaced with std::mutex
and std::lock_guard from c++11.
Boost is removed as a dependency
and the c++11 compiler flag is added.