### PR TITLE
Add appveyor CI to test regressions on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+os:
+  - Visual Studio 2013
+  - Visual Studio 2015
+
+configuration:
+  - Release
+
+build_script:
+  - md build
+  - cd build
+  - cmake .. 
+  - cmake --build . --config %CONFIGURATION%
+  
+test_script:
+  - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
+
+after_build:
+  - cmake --build . --config %CONFIGURATION% --target INSTALL 


### PR DESCRIPTION
Compiling and running the tests on Visual Studio 2013/2015. 

AppVeyor need to be enabled by the repo maintainers at https://www.appveyor.com . 

Example run at : https://ci.appveyor.com/project/traversaro/console-bridge/build/job/g1swcad37ab6v6p5 . 
Currently failing for https://github.com/ros/console_bridge/issues/34 . 