### PR TITLE
Fix tests on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
   option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
 endif()
 
+# Control where libraries and executables are placed during the build
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
 add_library(${PROJECT_NAME} src/console.cpp)
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION
                ${CONSOLE_BRIDGE_MAJOR_VERSION}.${CONSOLE_BRIDGE_MINOR_VERSION})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,9 @@ build_script:
   - cd build
   - cmake .. 
   - cmake --build . --config %CONFIGURATION%
-  
-# tests aren't yet working
-# test_script:
-#   - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
+
+test_script:
+  - cmake --build . --config %CONFIGURATION% --target RUN_TESTS
 
 after_build:
   - cmake --build . --config %CONFIGURATION% --target INSTALL 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,8 +45,9 @@ foreach(GTEST_SOURCE_file ${tests})
     target_link_libraries(${BINARY_NAME} pthread)
   endif()
 
-   add_test(${BINARY_NAME} ${CMAKE_CURRENT_BINARY_DIR}/${BINARY_NAME}
-       --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
+   add_test(NAME    ${BINARY_NAME}
+            COMMAND ${BINARY_NAME}
+                    --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
    set_tests_properties(${BINARY_NAME} PROPERTIES TIMEOUT 240)
 endforeach()


### PR DESCRIPTION
* Keep binaries and dll in the same build directory to avoid path issues.
  * Shamelessly copied the strategy from https://github.com/robotology/yarp/blob/aa779bdf3056d90a04acaf8d96dfc09100e960b9/conf/YarpOptions.cmake#L14 .
  * This is also convenient to use a library directly from the build directory. 
* Don't use the full path of the test binary in add_test . 
 * CMake will automatically expand a target to the full path ( `If <command> specifies an executable target (created by add_executable()) it will automatically be replaced by the location of the executable created at build time.` https://cmake.org/cmake/help/v3.0/command/add_test.html ). 
* Re-enable tests on AppVeyor . 