### PR TITLE
Fix static compilation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
   option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
 endif()
 
+if(NOT BUILD_SHARED_LIBS)
+  add_definitions(-DCONSOLE_BRIDGE_STATIC)
+endif()
+
 # Control where libraries and executables are placed during the build
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
Currently, compiling as a static library by setting `BUILD_SHARED_LIBS=OFF` fails on Windows, and the reason is that `CONSOLE_BRIDGE_STATIC` is not defined as it's supposed to in that case. A simple fix is included here.

The log for the build failure is below

```
d:\code\console_bridge\build>nmake

Microsoft (R) Program Maintenance Utility Version 12.00.21005.1
Copyright (C) Microsoft Corporation.  All rights reserved.

Scanning dependencies of target console_bridge
[ 12%] Building CXX object CMakeFiles/console_bridge.dir/src/console.cpp.obj
console.cpp
D:\code\console_bridge\src\console.cpp(82) : warning C4273: 'console_bridge::noOutputHandler' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(175) : see previous definition of 'noOutputHandler'
D:\code\console_bridge\src\console.cpp(89) : warning C4273: 'console_bridge::restorePreviousOutputHandler' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(178) : see previous definition of 'restorePreviousOutputHandler'
D:\code\console_bridge\src\console.cpp(95) : warning C4273: 'console_bridge::useOutputHandler' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(181) : see previous definition of 'useOutputHandler'
D:\code\console_bridge\src\console.cpp(102) : warning C4273: 'console_bridge::getOutputHandler' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(184) : see previous definition of 'getOutputHandler'
D:\code\console_bridge\src\console.cpp(108) : warning C4273: 'console_bridge::log_deprecated' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(202) : see previous definition of 'log_deprecated'
D:\code\console_bridge\src\console.cpp(133) : warning C4273: 'console_bridge::log' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(197) : see previous definition of 'log'
D:\code\console_bridge\src\console.cpp(153) : warning C4273: 'console_bridge::setLogLevel' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(188) : see previous definition of 'setLogLevel'
D:\code\console_bridge\src\console.cpp(159) : warning C4273: 'console_bridge::getLogLevel' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(192) : see previous definition of 'getLogLevel'
D:\code\console_bridge\src\console.cpp(167) : warning C4273: 'console_bridge::OutputHandlerSTD::log' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(151) : see previous definition of 'log'
D:\code\console_bridge\src\console.cpp(181) : warning C4273: 'console_bridge::OutputHandlerFile::OutputHandlerFile' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(161) : see previous definition of '{ctor}'
D:\code\console_bridge\src\console.cpp(194) : warning C4273: 'console_bridge::OutputHandlerFile::~OutputHandlerFile' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(163) : see previous definition of '{dtor}'
D:\code\console_bridge\src\console.cpp(201) : warning C4273: 'console_bridge::OutputHandlerFile::log' : inconsistent dll linkage
        D:\code\console_bridge\include\console_bridge/console.h(165) : see previous definition of 'log'
[ 25%] Linking CXX static library lib\console_bridge.lib
[ 25%] Built target console_bridge
Scanning dependencies of target gtest
[ 37%] Building CXX object test/CMakeFiles/gtest.dir/gtest/src/gtest-all.cc.obj
gtest-all.cc
[ 50%] Linking CXX static library ..\lib\gtest.lib
[ 50%] Built target gtest
Scanning dependencies of target gtest_main
[ 62%] Building CXX object test/CMakeFiles/gtest_main.dir/gtest/src/gtest_main.cc.obj
gtest_main.cc
[ 75%] Linking CXX static library ..\lib\gtest_main.lib
[ 75%] Built target gtest_main
Scanning dependencies of target console_TEST
[ 87%] Building CXX object test/CMakeFiles/console_TEST.dir/console_TEST.cc.obj
console_TEST.cc
[100%] Linking CXX executable ..\bin\console_TEST.exe
console_TEST.cc.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) void __cdecl console_bridge::log_deprecated(char const *,int,enum console_bridge::LogLevel,char const *,...)" (__imp_?log_deprecated@console_bridge@@YAXPBDHW4LogLevel@1@0ZZ) referenced in function "private: virtual void __thiscall ConsoleTest_MacroExpansionTest_ItShouldCompile_Test::TestBody(void)" (?TestBody@ConsoleTest_MacroExpansionTest_ItShouldCompile_Test@@EAEXXZ)
..\bin\console_TEST.exe : fatal error LNK1120: 1 unresolved externals
LINK failed. with 1120
NMAKE : fatal error U1077: '"C:\Program Files (x86)\CMake\bin\cmake.exe"' : return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
```
