### PR TITLE
console_bridge-config.cmake.in for cross compiling

### DIFF
--- a/console_bridge-config.cmake.in
+++ b/console_bridge-config.cmake.in
@@ -10,7 +10,7 @@ foreach(lib @PKG_LIBRARIES@)
   find_library(onelib ${lib}
     PATHS "@CMAKE_INSTALL_FULL_LIBDIR@"
     NO_DEFAULT_PATH
-    CMAKE_FIND_ROOT_PATH_BOTH
+    NO_CMAKE_FIND_ROOT_PATH
     )
   if(NOT onelib)
     message(FATAL_ERROR "Library '${lib}' in package @PKG_NAME@ is not installed properly")

--- a/console_bridge-config.cmake.in
+++ b/console_bridge-config.cmake.in
@@ -10,6 +10,7 @@ foreach(lib @PKG_LIBRARIES@)
   find_library(onelib ${lib}
     PATHS "@CMAKE_INSTALL_FULL_LIBDIR@"
     NO_DEFAULT_PATH
+    CMAKE_FIND_ROOT_PATH_BOTH
     )
   if(NOT onelib)
     message(FATAL_ERROR "Library '${lib}' in package @PKG_NAME@ is not installed properly")


### PR DESCRIPTION
My cross-compiling toolchain sets

set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

and console_bridge-config.cmake fails at the find_library line because the console_bridge library is on the host (ROS2 build). Is this a workable solution? Supported since cmake < 2.8