### PR TITLE
Don't link against pthread on Android

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ foreach(GTEST_SOURCE_file ${tests})
      gtest_main
      gtest
      console_bridge)
-  if (UNIX)
+  if (UNIX AND NOT ANDROID)
     target_link_libraries(${BINARY_NAME} pthread)
   endif()
 


### PR DESCRIPTION
Linking against pthread isn't needed on Android.