### PR TITLE
explicitly enable CMake policy 42 to prevent warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif()
+
 # If compiler support symbol visibility, enable it.
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-fvisibility=hidden HAS_VISIBILITY)


### PR DESCRIPTION
To get rid of the warning: http://ci.ros2.org/job/ci_osx/3164/warnings2Result/new/

Result with this patch: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3166)](http://ci.ros2.org/job/ci_osx/3166/)
  