### PR TITLE
use target include directories for gtest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,3 @@
-include_directories (
-  ${PROJECT_SOURCE_DIR}/test/gtest/include
-  ${PROJECT_SOURCE_DIR}/test/gtest
-  ${PROJECT_SOURCE_DIR}/test
-)
-
 link_directories(
   ${PROJECT_BINARY_DIR}/test
 )
@@ -11,12 +5,18 @@ link_directories(
 
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
+target_include_directories(gtest
+  PUBLIC
+  ${PROJECT_SOURCE_DIR}/test/gtest/include
+  ${PROJECT_SOURCE_DIR}/test/gtest
+  ${PROJECT_SOURCE_DIR}/test
+)
+
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)
 target_link_libraries(gtest_main gtest)
 
 execute_process(COMMAND cmake -E remove_directory ${CMAKE_BINARY_DIR}/test_results)
 execute_process(COMMAND cmake -E make_directory ${CMAKE_BINARY_DIR}/test_results)
-include_directories(${GTEST_INCLUDE_DIRS})
 
 set(tests
      console_TEST.cc)


### PR DESCRIPTION
This is related to https://github.com/ros2/ros2/issues/743

I think `tf2` is running into conflicts when using console bridge from homebrew ([v.0.4.3](https://github.com/Homebrew/homebrew-core/blob/0e28f3d23854ecca30cb3eeea80e949da348186f/Formula/console_bridge.rb#L4)) vs the version installed by the ros2 `console_bridge_vendor` package ([v.0.4.1](https://github.com/ros2/console_bridge_vendor/blob/d3be808a1b77028a152a8ee5aa56346ce32db987/CMakeLists.txt#L54)). 
My believe is that setting the global include directories for gtest might cause the trouble where an inconsistent state between library of `ament_cmake_gtest` and the `console_bridge` gtest headers occurs. 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>