### PR TITLE
fix clang warnings

### DIFF
--- a/include/console_bridge/console.h
+++ b/include/console_bridge/console.h
@@ -63,17 +63,17 @@
 
     \}
 */
-#define CONSOLE_BRIDGE_logError(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logError(...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logWarn(...)   \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logInform(fmt, ...) \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logInform(...) \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logDebug(...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, __VA_ARGS__)
 
 
 /** \brief Message namespace. This contains classes needed to


### PR DESCRIPTION
When compiling `console_bridge` with `clang`, I get the following warnings:
```
In file included from /vol/sandbox/ros2/src/srdfdom/src/model.cpp:38:
/opt/ros/dashing/include/console_bridge/console.h:67:90: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
```