### PR TITLE
Add test for macros with multiple arguments

### DIFF
--- a/test/console_TEST.cc
+++ b/test/console_TEST.cc
@@ -25,3 +25,11 @@ TEST(ConsoleTest, MacroExpansionTest_ItShouldCompile)
     CONSOLE_BRIDGE_logDebug("Testing Log");
   }
 }
+
+//////////////////////////////////////////////////
+TEST(ConsoleTest, MultipleArguments)
+{
+  CONSOLE_BRIDGE_logError("no extra parameters");
+  CONSOLE_BRIDGE_logError("one integer: %d", 42);
+  CONSOLE_BRIDGE_logError("two floats: %f, %.2f", 42.01, 1/3.0);
+}


### PR DESCRIPTION
I wrote the following test while reviewing #64 but added it to a separate pull request to keep things simple.

On my machine it prints:

~~~
[ RUN      ] ConsoleTest.MultipleArguments
Error:   no extra parameters
         at line 32 in /Users/scpeters/clone/console_bridge/test/console_TEST.cc
Error:   one integer: 42
         at line 33 in /Users/scpeters/clone/console_bridge/test/console_TEST.cc
Error:   two floats: 42.010000, 0.33
         at line 34 in /Users/scpeters/clone/console_bridge/test/console_TEST.cc
[       OK ] ConsoleTest.MultipleArguments (0 ms)
~~~