### PR TITLE
Add tests for OutputFileHandler

### DIFF
--- a/test/console_TEST.cc
+++ b/test/console_TEST.cc
@@ -285,7 +285,7 @@ private:
 };
 
 TEST_F(FileHandlerTest, TestInformDoesntLog) {
-  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  // Use scoping to call ~OutputHandlerFile() and force in to flush contents and close file
   {
     const std::string text = "Some logging text";
     console_bridge::OutputHandlerFile handler(log_filename());
@@ -301,7 +301,7 @@ TEST_F(FileHandlerTest, TestInformDoesntLog) {
 TEST_F(FileHandlerTest, TestErrorLogs) {
   const std::string text = "Some logging text";
 
-  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  // Use scoping to call ~OutputHandlerFile() and force in to flush contents and close file
   {
     console_bridge::OutputHandlerFile handler(log_filename());
     console_bridge::useOutputHandler(&handler);
@@ -318,7 +318,7 @@ TEST_F(FileHandlerTest, TestErrorLogs) {
 TEST_F(FileHandlerTest, TestInformLogsWithLogLevel) {
   const std::string text = "Some logging text";
 
-  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  // Use scoping to call ~OutputHandlerFile() and force in to flush contents and close file
   {
     console_bridge::OutputHandlerFile handler(log_filename());
     console_bridge::useOutputHandler(&handler);

--- a/test/console_TEST.cc
+++ b/test/console_TEST.cc
@@ -33,6 +33,8 @@
 *********************************************************************/
 
 #include <cassert>
+#include <fstream>
+#include <sstream>
 #include <gtest/gtest.h>
 
 #include <console_bridge/console.h>
@@ -81,6 +83,15 @@ TEST(ConsoleTest, MacroExpansionTest_ItShouldCompile)
   {
     CONSOLE_BRIDGE_logDebug("Testing Log");
   }
+}
+
+//////////////////////////////////////////////////
+TEST(ConsoleTest, StdoutStderrOutput)
+{
+  CONSOLE_BRIDGE_logDebug("Testing Log");
+  CONSOLE_BRIDGE_logInform("Testing Log");
+  CONSOLE_BRIDGE_logWarn("Testing Log");
+  CONSOLE_BRIDGE_logError("Testing Log");
 }
 
 //////////////////////////////////////////////////
@@ -233,4 +244,77 @@ TEST(ConsoleTest, TestLogLevel)
 
   console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_NONE);
   EXPECT_EQ(console_bridge::getLogLevel(), console_bridge::CONSOLE_BRIDGE_LOG_NONE);
+}
+
+TEST(ConsoleTest, TestOutputHandlerFileBadFilename) {
+  console_bridge::OutputHandlerFile handler("/really/hoping/this/path/doesnt/exist.txt");
+  EXPECT_NO_THROW(
+    handler.log("This should not crash", console_bridge::CONSOLE_BRIDGE_LOG_WARN, "file.cpp", 42));
+
+  console_bridge::useOutputHandler(&handler);
+  EXPECT_NO_THROW(
+    CONSOLE_BRIDGE_logError("This also should not crash, nor actually log anything"));
+  // ~OutputHandlerFile() should not fail to close a non-existent file handle
+}
+
+class FileHandlerTest : public ::testing::Test {
+public:
+  FileHandlerTest() : log_filename_("tmp.txt") {}
+
+  virtual void TearDown()
+  {
+    remove(log_filename());
+  }
+
+  std::string getTextFromLogFile() {
+    std::ifstream f(log_filename_);
+    std::stringstream result;
+    result << f.rdbuf();
+    return result.str();
+  }
+
+  const char * log_filename() { return log_filename_.c_str(); }
+
+private:
+  std::string log_filename_;
+};
+
+TEST_F(FileHandlerTest, TestInformDoesntLog) {
+  const std::string text = "Some logging text";
+  console_bridge::OutputHandlerFile handler(log_filename());
+  console_bridge::useOutputHandler(&handler);
+  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_WARN);
+  CONSOLE_BRIDGE_logInform("This shouldn't log to file because it's only inform");
+
+  const std::string result = getTextFromLogFile();
+  EXPECT_TRUE(result.empty()) << "Log file was not empty, it contained:\n\n" << result;
+}
+
+TEST_F(FileHandlerTest, TestErrorLogs) {
+  const std::string text = "Some logging text";
+  console_bridge::OutputHandlerFile handler(log_filename());
+  console_bridge::useOutputHandler(&handler);
+  CONSOLE_BRIDGE_logError(text.c_str());
+
+  const std::string expected_text = "Error:   " + text;
+  const std::string result = getTextFromLogFile();
+
+  // Just checking that expected text is in the file, not checking full log statement.
+  EXPECT_NE(result.find(expected_text), result.npos)
+    << "Log file did not contain expected text, instead it contained:\n\n: " << result;
+}
+
+TEST_F(FileHandlerTest, TestInformLogsWithLogLevel) {
+  const std::string text = "Some logging text";
+  console_bridge::OutputHandlerFile handler(log_filename());
+  console_bridge::useOutputHandler(&handler);
+  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
+  CONSOLE_BRIDGE_logInform(text.c_str());
+
+  const std::string expected_text = "Info:    " + text;
+  const std::string result = getTextFromLogFile();
+
+  // Just checking that expected text is in the file, not checking full log statement.
+  EXPECT_NE(result.find(expected_text), result.npos)
+    << "Log file did not contain expected text, instead it contained:\n\n: " << result;
 }

--- a/test/console_TEST.cc
+++ b/test/console_TEST.cc
@@ -88,10 +88,15 @@ TEST(ConsoleTest, MacroExpansionTest_ItShouldCompile)
 //////////////////////////////////////////////////
 TEST(ConsoleTest, StdoutStderrOutput)
 {
-  CONSOLE_BRIDGE_logDebug("Testing Log");
-  CONSOLE_BRIDGE_logInform("Testing Log");
-  CONSOLE_BRIDGE_logWarn("Testing Log");
-  CONSOLE_BRIDGE_logError("Testing Log");
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_DEBUG);
+  EXPECT_NO_THROW(
+    CONSOLE_BRIDGE_logDebug("Testing Log"));
+  EXPECT_NO_THROW(
+    CONSOLE_BRIDGE_logInform("Testing Log"));
+  EXPECT_NO_THROW(
+    CONSOLE_BRIDGE_logWarn("Testing Log"));
+  EXPECT_NO_THROW(
+    CONSOLE_BRIDGE_logError("Testing Log"));
 }
 
 //////////////////////////////////////////////////
@@ -280,11 +285,14 @@ private:
 };
 
 TEST_F(FileHandlerTest, TestInformDoesntLog) {
-  const std::string text = "Some logging text";
-  console_bridge::OutputHandlerFile handler(log_filename());
-  console_bridge::useOutputHandler(&handler);
-  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_WARN);
-  CONSOLE_BRIDGE_logInform("This shouldn't log to file because it's only inform");
+  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  {
+    const std::string text = "Some logging text";
+    console_bridge::OutputHandlerFile handler(log_filename());
+    console_bridge::useOutputHandler(&handler);
+    console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_WARN);
+    CONSOLE_BRIDGE_logInform("This shouldn't log to file because it's only inform");
+  }
 
   const std::string result = getTextFromLogFile();
   EXPECT_TRUE(result.empty()) << "Log file was not empty, it contained:\n\n" << result;
@@ -292,10 +300,13 @@ TEST_F(FileHandlerTest, TestInformDoesntLog) {
 
 TEST_F(FileHandlerTest, TestErrorLogs) {
   const std::string text = "Some logging text";
-  console_bridge::OutputHandlerFile handler(log_filename());
-  console_bridge::useOutputHandler(&handler);
-  CONSOLE_BRIDGE_logError(text.c_str());
 
+  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  {
+    console_bridge::OutputHandlerFile handler(log_filename());
+    console_bridge::useOutputHandler(&handler);
+    CONSOLE_BRIDGE_logError(text.c_str());
+  }
   const std::string expected_text = "Error:   " + text;
   const std::string result = getTextFromLogFile();
 
@@ -306,10 +317,14 @@ TEST_F(FileHandlerTest, TestErrorLogs) {
 
 TEST_F(FileHandlerTest, TestInformLogsWithLogLevel) {
   const std::string text = "Some logging text";
-  console_bridge::OutputHandlerFile handler(log_filename());
-  console_bridge::useOutputHandler(&handler);
-  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
-  CONSOLE_BRIDGE_logInform(text.c_str());
+
+  // Use scoping to call ~OutputHandelFile() and force in to flush contents and close file
+  {
+    console_bridge::OutputHandlerFile handler(log_filename());
+    console_bridge::useOutputHandler(&handler);
+    console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
+    CONSOLE_BRIDGE_logInform(text.c_str());
+  }
 
   const std::string expected_text = "Info:    " + text;
   const std::string result = getTextFromLogFile();

--- a/test/console_TEST.cc
+++ b/test/console_TEST.cc
@@ -266,6 +266,12 @@ class FileHandlerTest : public ::testing::Test {
 public:
   FileHandlerTest() : log_filename_("tmp.txt") {}
 
+  virtual void SetUp()
+  {
+    // Needs to be reset to avoid side effects from other tests
+    console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_WARN);
+  }
+
   virtual void TearDown()
   {
     remove(log_filename());
@@ -290,7 +296,6 @@ TEST_F(FileHandlerTest, TestInformDoesntLog) {
     const std::string text = "Some logging text";
     console_bridge::OutputHandlerFile handler(log_filename());
     console_bridge::useOutputHandler(&handler);
-    console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_WARN);
     CONSOLE_BRIDGE_logInform("This shouldn't log to file because it's only inform");
   }
 
@@ -317,12 +322,12 @@ TEST_F(FileHandlerTest, TestErrorLogs) {
 
 TEST_F(FileHandlerTest, TestInformLogsWithLogLevel) {
   const std::string text = "Some logging text";
+  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
 
   // Use scoping to call ~OutputHandlerFile() and force in to flush contents and close file
   {
     console_bridge::OutputHandlerFile handler(log_filename());
     console_bridge::useOutputHandler(&handler);
-    console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
     CONSOLE_BRIDGE_logInform(text.c_str());
   }
 


### PR DESCRIPTION
It looks like OutputFileHandler was the only feature that is not currently tested in this package. This adds a test for that, and also basic stdout/stderr smoke tests.

Signed-off-by: Stephen Brawner <brawner@gmail.com>