### PR TITLE
removes -lpthread when building for QNX

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(GTEST_SOURCE_file ${tests})
      gtest_main
      gtest
      console_bridge)
-  if (UNIX AND NOT ANDROID)
+  if (UNIX AND NOT ANDROID AND NOT QNX)
     target_link_libraries(${BINARY_NAME} pthread)
   endif()
 


### PR DESCRIPTION
part of the work done for QNX support https://github.com/ros2/ros2/issues/988