### PR TITLE
Added arch ppc64leTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+ - amd64
+ - ppc64le
+ 
 os: linux
 dist: trusty
 language: cpp


### PR DESCRIPTION
Hi,
Added power support for the travis.yml file with ppc64le. 
This is part of the Ubuntu distribution for ppc64le.