### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+arch:
+ - amd64
+ - ppc64le
+ 
+ 
 os: linux
 dist: trusty
 language: cpp


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/console_bridge/builds/198240914

Please have a look.

Regards,
Manish Kumar