### PR TITLE
Provide PROJECT_SOURCE_DIR to cpplint

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,7 @@ if(WGET_EXE)
                    "--counting=detailed"
                    "--extensions=cpp,h"
                    "--linelength=100"
+                   "--repository=${PROJECT_SOURCE_DIR}"
                    "--filter=-build/c++11,-runtime/references,-whitespace/braces,-whitespace/indent,-whitespace/parens,-whitespace/semicolon"
            "${PROJECT_SOURCE_DIR}/include/console_bridge/console.h"
            "${PROJECT_SOURCE_DIR}/src/console.cpp"


### PR DESCRIPTION
to fix eg:

```
3/3 Test #3: console_bridge_cpplint3/3 Test #3: console_bridge_cpplint............***Failed    0.15 sec
…/src/console_bridge-1.0.2/include/console_bridge/console.h:37:  #ifndef header guard has wrong style, please use: SRC_CONSOLE_BRIDGE_1_0_2_INCLUDE_CONSOLE_BRIDGE_CONSOLE_H_  [build/header_guard] [5]
…/src/console_bridge-1.0.2/include/console_bridge/console.h:192:  #endif line should be "#endif  // SRC_CONSOLE_BRIDGE_1_0_2_INCLUDE_CONSOLE_BRIDGE_CONSOLE_H_"  [build/header_guard] [5]