### PR TITLE
Update doxygen.yml

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install base dependencies
       run: |
         sudo apt update;


### PR DESCRIPTION
ubuntu 20.04 Ended  support  : 31 May 2025
fix node.js deprecation into action/checkout